### PR TITLE
[Github Actions] enable sync to main for notebook repo in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,6 +94,7 @@ jobs:
           source-directory: '_build/lecture-julia.notebooks/'
           destination-repository-username: 'QuantEcon'
           destination-repository-name: 'lecture-julia.notebooks'
+          target-branch: main
           commit-message: 'auto publishing updates to notebooks'
           destination-github-username: 'quantecon-services'
           user-email: services@quantecon.org


### PR DESCRIPTION
updates from `master` to `main`