### PR TITLE
MAINT: Updates to github actions and repo infrastructure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,6 +83,8 @@ jobs:
           mkdir -p _build/lecture-julia.notebooks
           cp -a _notebook_repo/. _build/lecture-julia.notebooks
           cp -a _build/jupyter/. _build/lecture-julia.notebooks
+          rm -r _build/lecture-julia.notebooks/_static
+          rm -r _build/lecture-julia.notebooks/_panels_static
           cp lectures/Project.toml _build/lecture-julia.notebooks
           cp lectures/Manifest.toml _build/lecture-julia.notebooks
           ls -a _build/lecture-julia.notebooks

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+.DS_Store
+**/.ipynb_checkpoints
+.vscode/settings.json
 _build


### PR DESCRIPTION
Update notebook sync in publish workflow to remove static assets from notebook repo

fixes #107, #108