### PR TITLE
DEPLOY: enable cname setting in gh-pages for custom domain

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: _build/html/
-          # cname: julia.quantecon.org
+          cname: julia.quantecon.org
       - name: Upload "_build" folder (cache)
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
This PR enables the cname record to be set by `publish.yml` workflow when `dns` is switched to `gh-pages`