### PR TITLE
MAINT: switch from push to pull_request for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: Build Project [using jupyter-book]
-on: [push]
+on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Change `ci.yml` to run on `pull_request` rather than `push`