### PR TITLE
Switched to kwdef from Base

### DIFF
--- a/lectures/getting_started_julia/introduction_to_types.md
+++ b/lectures/getting_started_julia/introduction_to_types.md
@@ -483,12 +483,13 @@ The code works, and is equivalent in performance to a `NamedTuple`, but is more 
 
 There is no way to avoid learning parametric types to achieve high performance code.
 
-However, the other issue where constructor arguments are error-prone, can be remedied with the `Parameters.jl` library.
+However, the other issue where constructor arguments are error-prone can be
+remedied with the `@kwdef` macro from `Base`.
 
 ```{code-cell} julia
-using Parameters
+import Base.@kwdef
 
-@with_kw  struct Foo5
+@kwdef  struct Foo5
     a::Float64 = 2.0     # adds default value
     b::Int64
     c::Vector{Float64}

--- a/lectures/getting_started_julia/introduction_to_types.md
+++ b/lectures/getting_started_julia/introduction_to_types.md
@@ -487,9 +487,9 @@ However, the other issue where constructor arguments are error-prone can be
 remedied with the `@kwdef` macro from `Base`.
 
 ```{code-cell} julia
-import Base.@kwdef
+using Base: @kwdef
 
-@kwdef  struct Foo5
+@kwdef struct Foo5
     a::Float64 = 2.0     # adds default value
     b::Int64
     c::Vector{Float64}


### PR DESCRIPTION
Did you want to switch this to `@kwdef` from `Base` now that it's available (rather than using `Parameters.jl`) @jlperla ?

I've confirmed that output is the same.

Free disposal applies -- I'm just assuming this capability has recently migrated to Base.