### PR TITLE
Update to optimal growth lecture

### DIFF
--- a/lectures/dynamic_programming/optgrowth.md
+++ b/lectures/dynamic_programming/optgrowth.md
@@ -506,7 +506,7 @@ function T(w;p, tol = 1e-10)
     σ = similar(w)
     for (i, y_val) in enumerate(y)
         # solve maximization for each point in y, using y itself as initial condition.
-        results = maximize(c -> u(c;p) + β * mean(w_func.(f(y_val - c;p) .* ξ)), tol, y_val) # solver result for each grid point        
+        results = maximize(c -> u(c;p) + β * mean(w_func.(f(y_val - c;p) .* ξ)), tol, y_val)
         Tw[i] = maximum(results)
         σ[i] = maximizer(results)
     end
@@ -583,20 +583,6 @@ end
 c_star(y;p) = (1 - p.α * p.β) * y
 ```
 
-
-```{code-cell} julia
----
-tags: [remove-cell]
----
-# # Unused in code, can add back in as required.
-#∂u∂c(c) = 1 / c
-#f′(k;p) = p.α * k^(p.α - 1)
-
-@testset "Primitives Tests" begin
-    @test v_star(3.0;p = OptimalGrowthModel()) ≈ -25.245288867900843
-end
-```
-
 ### A First Test
 
 To test our code, we want to see if we can replicate the analytical solution numerically, using fitted value function iteration.
@@ -642,7 +628,7 @@ for i in 1:n
 end
 
 lb = "true value function"
-plot!(plt, y -> v_star(y; p), grid_y, color = :black, linewidth = 2, alpha = 0.8, label = lb)
+plot!(plt, p.y, v_star.(p.y; p), color = :black, linewidth = 2, alpha = 0.8, label = lb)
 plot!(plt, legend = :bottomright)
 ```
 

--- a/lectures/dynamic_programming/optgrowth.md
+++ b/lectures/dynamic_programming/optgrowth.md
@@ -500,25 +500,26 @@ Here's a function that implements the Bellman operator using linear interpolatio
 ```{code-cell} julia
 function T(w;p, tol = 1e-10)
     @unpack β, u, f, ξ, y = p # unpack parameters
-    # w_func = LinearInterpolation(y, w)
+    w_func = LinearInterpolation(y, w)
 
-    # Tw = similar(w)
-    # σ = similar(w)
-    # for (i, y_val) in enumerate(y)
-    #     # solve maximization for each point in y, using y itself as initial condition.
-    #     results = maximize(c -> u(c;p) + β * mean(w_func.(f(y_val - c;p) .* ξ)), tol, y_val) # solver result for each grid point        
-    #     Tw[i] = maximum(results)
-    #     σ[i] = maximizer(results)
-    # end
+    Tw = similar(w)
+    σ = similar(w)
+    for (i, y_val) in enumerate(y)
+        # solve maximization for each point in y, using y itself as initial condition.
+        results = maximize(c -> u(c;p) + β * mean(w_func.(f(y_val - c;p) .* ξ)), tol, y_val) # solver result for each grid point        
+        Tw[i] = maximum(results)
+        σ[i] = maximizer(results)
+    end
    
-    grid = y
-    shocks = ξ   
-    w_func = LinearInterpolation(grid, w)
-    objectives = (c -> u(c;p) + β * mean(w_func.(f(y - c;p) .* shocks)) for y in grid)
-    results = maximize.(objectives, 1e-10, grid) # solver result for each grid point
-
-    Tw = Optim.maximum.(results)
-    σ = Optim.maximizer.(results)
+    # # OLD TO COMPARE AND REMOVE
+    # grid = y
+    # shocks = ξ   
+    # w_func = LinearInterpolation(grid, w)
+    # objectives = (c -> u(c;p) + β * mean(w_func.(f(y - c;p) .* shocks)) for y in grid)
+    # results = maximize.(objectives, 1e-10, grid) # solver result for each grid point
+# 
+    # Tw = Optim.maximum.(results)
+    # σ = Optim.maximizer.(results)
     return (;w = Tw, σ) # returns named tuple of results
 end
 ```


### PR DESCRIPTION
@jstac  In progress.  Will finish soon but you can take a look to see one approach, and then take this over and change it however you wish.

One option I sometimes do in "real" code is to separate out a named tuple for the deep model parameters from the settings specific to an algorithm (e.g. `params` vs. `settings`).  But this seemed like overkill here, so they are combined in one named tuple.

To give you just one example of the problem of a struct:  the "grid" for y shouldn't be an array if it is regular since a range is a separate iterable type with supported `enumerate`.  Besides more efficient iteration, it also leads to specialized dispatches for the linear interpolation/etc which are specialized for regular grids/etc. Of course, you may also want to support irregular grids so you don't want to hardcode it as a range either.   All of that happens behind the scenes as long as you leave types generic and don't convert them unnecessarily.   Named tuples just "duck type" it all so the intro coder doesn't need to think through any of that.

The simplest way to get this to work with a struct and not have any chance to shoot yourself in the foot or have an unnecessary drop in performance is just to use a `kwarg` and leave everything parametric.  e.g.
```
Base.@kwdef MyModel{T1, T2, T3}
   a::T1 = ???
   b::T2 = ???
   c::T3 = ???
end
mod = MyModel()
mod2 = MyModel(a = ???, b = ???)  # going over top of defaults.
```
This is totally fine, but it is also equivalent to just using a named tuple, but requires more explanation or syntax.

The biggest benefit of using a struct, however, is that it is easier to use an outer-constructor to calculate some cosntants for reuse.  When you have lots of sub-calculations given parameters that is worth it, but I don't think that it is worth it for just the `v_star` - which doesn't require high performance and can just redo the calculations each time.  You can often do the same thing with named tuples by just chaining the construction, e..g `model = @with_kw (a = 3.0, b = 5, c = my_func(a, b))` then `model(a = 5.0)` will do exactly what you want, and set `c = my_func(5.0, 5)`