### PR TITLE
FIX: specify main branch for binder launcher link

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -51,6 +51,7 @@ sphinx:
       repository_url: https://github.com/QuantEcon/lecture-julia.myst
       repository_branch: main
       nb_repository_url: https://github.com/QuantEcon/lecture-julia.notebooks
+      nb_branch: main
       twitter: quantecon
       twitter_logo_url: https://assets.quantecon.org/img/qe-twitter-logo.png
       og_logo_url: https://assets.quantecon.org/img/qe-og-logo.png


### PR DESCRIPTION
@jbrightuniverse this adds `main` instead of `master` to the binder launcher links