### PR TITLE
Anderson m setting in McCall notebook

### DIFF
--- a/lectures/dynamic_programming/mccall_model.md
+++ b/lectures/dynamic_programming/mccall_model.md
@@ -301,10 +301,6 @@ tags: [remove-cell]
 using Test
 ```
 
-```{code-cell} julia
-
-```
-
 Here's the distribution of wage offers we'll work with
 
 ```{code-cell} julia
@@ -411,8 +407,7 @@ function compute_reservation_wage(params; v_iv = collect(w ./(1-β)), iterations
     @unpack c, β, w = params
     T(v) = max.(w/(1 - β), c + β * E*v) # (5) fixing the parameter values
 
-    v_star = fixedpoint(T, v_iv, iterations = iterations, ftol = ftol,
-                        m = 0).zero # (5)
+    v_star = fixedpoint(T, v_iv; iterations, ftol , m).zero # (5)
     return (1 - β) * (c + β * E*v_star) # (3)
 end
 ```


### PR DESCRIPTION
closes #146 

@jlperla the default setting is failing to converge, not sure how to handle it:

```
LAPACKException(6)

Stacktrace:
  [1] chklapackerror(ret::Int64)
    @ LinearAlgebra.LAPACK C:\Users\jbrig\AppData\Local\Programs\Julia-1.7.1\share\julia\stdlib\v1.7\LinearAlgebra\src\lapack.jl:43
  [2] trtrs!(uplo::Char, trans::Char, diag::Char, A::SubArray{Float64, 2, Matrix{Float64}, Tuple{UnitRange{Int64}, UnitRange{Int64}}, false}, B::SubArray{Float64, 1, Vector{Float64}, Tuple{UnitRange{Int64}}, true})
    @ LinearAlgebra.LAPACK C:\Users\jbrig\AppData\Local\Programs\Julia-1.7.1\share\julia\stdlib\v1.7\LinearAlgebra\src\lapack.jl:3431
  [3] ldiv!
    @ C:\Users\jbrig\AppData\Local\Programs\Julia-1.7.1\share\julia\stdlib\v1.7\LinearAlgebra\src\triangular.jl:727 [inlined]
  [4] anderson_(df::OnceDifferentiable{Vector{Float64}, Matrix{Float64}, Vector{Float64}}, initial_x::Vector{Float64}, xtol::Float64, ftol::Float64, iterations::Int64, store_trace::Bool, show_trace::Bool, extended_trace::Bool, beta::Int64, aa_start::Int64, droptol::Int64, cache::NLsolve.AndersonCache{Vector{Float64}, Vector{Float64}, Vector{Vector{Float64}}, Vector{Float64}, Matrix{Float64}, Matrix{Float64}})
    @ NLsolve C:\Users\jbrig\.julia\packages\NLsolve\gJL1I\src\solvers\anderson.jl:160
  [5] anderson(df::OnceDifferentiable{Vector{Float64}, Matrix{Float64}, Vector{Float64}}, initial_x::Vector{Float64}, xtol::Float64, ftol::Float64, iterations::Int64, store_trace::Bool, show_trace::Bool, extended_trace::Bool, beta::Int64, aa_start::Int64, droptol::Int64, cache::NLsolve.AndersonCache{Vector{Float64}, Vector{Float64}, Vector{Vector{Float64}}, Vector{Float64}, Matrix{Float64}, Matrix{Float64}})
    @ NLsolve C:\Users\jbrig\.julia\packages\NLsolve\gJL1I\src\solvers\anderson.jl:203
  [6] anderson(df::OnceDifferentiable{Vector{Float64}, Matrix{Float64}, Vector{Float64}}, initial_x::Vector{Float64}, xtol::Float64, ftol::Float64, iterations::Int64, store_trace::Bool, show_trace::Bool, extended_trace::Bool, m::Int64, beta::Int64, aa_start::Int64, droptol::Int64)
    @ NLsolve C:\Users\jbrig\.julia\packages\NLsolve\gJL1I\src\solvers\anderson.jl:188
  [7] nlsolve(df::OnceDifferentiable{Vector{Float64}, Matrix{Float64}, Vector{Float64}}, initial_x::Vector{Float64}; method::Symbol, xtol::Float64, ftol::Float64, iterations::Int64, store_trace::Bool, show_trace::Bool, extended_trace::Bool, linesearch::Static, linsolve::NLsolve.var"#27#29", factor::Float64, autoscale::Bool, m::Int64, beta::Int64, aa_start::Int64, droptol::Int64)
    @ NLsolve C:\Users\jbrig\.julia\packages\NLsolve\gJL1I\src\nlsolve\nlsolve.jl:30
  [8] fixedpoint(f::var"#T#33"{StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}, Int64}, Float64, Float64}, initial_x::Vector{Float64}; method::Symbol, xtol::Float64, ftol::Float64, iterations::Int64, store_trace::Bool, show_trace::Bool, extended_trace::Bool, linesearch::Static, factor::Float64, autoscale::Bool, m::Int64, beta::Int64, droptol::Int64, autodiff::Symbol, inplace::Bool)
    @ NLsolve C:\Users\jbrig\.julia\packages\NLsolve\gJL1I\src\nlsolve\fixedpoint.jl:34
  [9] compute_reservation_wage(params::NamedTuple{(:c, :β, :w), Tuple{Float64, Float64, StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}, Int64}}}; v_iv::Vector{Float64}, iterations::Int64, ftol::Float64, m::Int64)
    @ Main .\In[27]:6
 [10] compute_reservation_wage(params::NamedTuple{(:c, :β, :w), Tuple{Float64, Float64, StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}, Int64}}})
    @ Main .\In[27]:3
 [11] top-level scope
    @ In[28]:3
 [12] eval
    @ .\boot.jl:373 [inlined]
 [13] include_string(mapexpr::typeof(REPL.softscope), mod::Module, code::String, filename::String)
    @ Base .\loading.jl:1196
```