### PR TITLE
ENH: enable svg image converter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,8 @@ jobs:
             texlive-luatex            \
             dvipng                    \
             ghostscript               \
-            cm-super 
+            cm-super                  \
+            inkscape
       - name: Set up Julia
         uses: julia-actions/setup-julia@v1
         with:

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -18,7 +18,7 @@ latex:
       targetname: quantecon-julia.tex
 
 sphinx:
-  extra_extensions: [sphinx_multitoc_numbering, sphinxext.rediraffe, sphinx_tojupyter]
+  extra_extensions: [sphinx_multitoc_numbering, sphinxext.rediraffe, sphinx_tojupyter, sphinxcontrib.inkscapeconverter]
   config:
     nb_render_priority:
       html:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ quantecon-book-theme==0.3.1
 sphinx-tojupyter==0.2.1
 sphinxext.rediraffe==0.2.7
 jupyter-server<2
+sphinxcontrib-svg2pdfconverter


### PR DESCRIPTION
This PR is testing the `sphinxcontrib.inkscapeconverter` to see if we can add svg image conversion for LaTeX