### PR TITLE
FIX: jupyter-book build cache

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -52,3 +52,4 @@ jobs:
         with:
           name: build-cache
           path: _build
+          include-hidden-files: true


### PR DESCRIPTION
This PR fixes an issue with the build cache due to the GitHub action not including hidden files in the build cache. 