### PR TITLE
FIX: compatibility with collab

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -98,5 +98,5 @@ sphinx:
         kernelspec:
           display_name: Julia
           language: julia
-          name: julia-1.11
+          name: julia
     tojupyter_images_markdown: true


### PR DESCRIPTION
This PR looks to fix compatibility with `google collab` new `julia` option. 

This updates the generated `download notebooks` with `julia` kernel name rather than `julia-1.11` which is version specific. 

see #330 